### PR TITLE
Workaround: tag might have no value

### DIFF
--- a/lib/utils/get-theme.js
+++ b/lib/utils/get-theme.js
@@ -9,7 +9,7 @@ export const getTheme = (customTheme) => ({
   h4: (value) => style(customTheme.h4 || 'cyan bold', value),
   h5: (value) => style(customTheme.h5 || 'cyan', value),
   h6: (value) => style(customTheme.h6 || 'cyan', value),
-  a: (value) => style(customTheme.a || 'blue underline', value),
+  a: (value) => style(customTheme.a || 'blue underline', value || ''),
   figcaption: (value) => style(customTheme.figcaption || 'bgGreen bold', value),
   blockquote: (value) => style(customTheme.blockquote || 'black', value),
   code: (value) => style(customTheme.inlineCode || 'yellowBright', value),


### PR DESCRIPTION
This PR is not really a solution but a workaround. 

Parsing is broken for various websites because value on a link might be null or undefined. I don't know how to best debug this one.

But here you can give a quick check to websites with the issue:

- Clone https://codeberg.org/hacktivista/w3cat.git
- Install `firefox`
- Run `npm install`
- Run `node ./main.js <url>`

**URLs that work**

- https://github.com/grigorii-horos/cli-html
- https://www.npmjs.com/package/cli-html

**URLs that do not**

- https://gitlab.com/gardenappl/readability-cli
- https://duckduckgo.com/

**URLs that do not work even with this workaround**

- https://codeberg.org/hacktivista/w3cat (issue is with tag italic on this one)