### PR TITLE
Improve progress tag and add tests

### DIFF
--- a/lib/tags/progress.js
+++ b/lib/tags/progress.js
@@ -11,13 +11,15 @@ export const progress = inlineTag((value, tag) => {
   const value2 = getAttribute(tag, 'value', '0');
   const max = getAttribute(tag, 'max', '0');
 
-  const pads = Math.round((Number.parseFloat(value2, 10) / (Number.parseFloat(max, 10) - 0.0001)) * 20);
+  let ratio = Number(value2) / (Number(max) || 1);
+  ratio = Math.min(1, Math.max(0, ratio));
+  const pads = Math.round(ratio * 20);
 
-  const progressstart = ''.padStart(pads, '█');
-  const progressEnd = ''.padStart(20 - pads, '█');
+  const progressStart = '█'.repeat(pads);
+  const progressEnd = '█'.repeat(20 - pads);
 
   return ` ${
-    bgWhite.green(progressstart)
+    bgWhite.green(progressStart)
   }${
     bgBlack.grey(progressEnd)
   }`;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "fix": "eslint --fix index.js lib/*.js lib/*/*.js",
-    "test": "true"
+    "test": "FORCE_COLOR=1 node --test"
   },
   "bin": {
     "html": "bin/html.js"

--- a/test/progress.test.js
+++ b/test/progress.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.FORCE_COLOR = '1';
+import htmlToCli from '../index.js';
+
+const progressRegex = /\x1b\[47m\x1b\[32m([^\x1b]*)\x1b\[39m\x1b\[49m\x1b\[40m\x1b\[90m([^\x1b]*)\x1b\[39m\x1b\[49m/;
+
+function getBarLengths(html) {
+  const output = htmlToCli(html);
+  let match = output.match(progressRegex);
+  if (match) {
+    return [match[1].length, match[2].length];
+  }
+  match = output.match(/\x1b\[47m\x1b\[32m([^\x1b]*)\x1b\[39m\x1b\[49m/);
+  if (match) {
+    return [match[1].length, 0];
+  }
+  match = output.match(/\x1b\[40m\x1b\[90m([^\x1b]*)\x1b\[39m\x1b\[49m/);
+  if (match) {
+    return [0, match[1].length];
+  }
+  return null;
+}
+
+test('progress bar is half filled', () => {
+  const [filled, empty] = getBarLengths('<progress value="50" max="100"></progress>');
+  assert.equal(filled, 10);
+  assert.equal(empty, 10);
+});
+
+test('progress value exceeding max clamps to full', () => {
+  const [filled, empty] = getBarLengths('<progress value="150" max="100"></progress>');
+  assert.equal(filled, 20);
+  assert.equal(empty, 0);
+});
+
+test('progress with zero value is empty', () => {
+  const [filled, empty] = getBarLengths('<progress value="0" max="100"></progress>');
+  assert.equal(filled, 0);
+  assert.equal(empty, 20);
+});
+
+test('progress with missing max defaults to 1', () => {
+  const [filled, empty] = getBarLengths('<progress value="0.5"></progress>');
+  assert.equal(filled, 10);
+  assert.equal(empty, 10);
+});


### PR DESCRIPTION
## Summary
- fix ratio calculation and bar generation in progress tag
- ensure consistent camelCase variable naming
- test progress bar rendering with various values
- run tests with forced colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68415ec99bd8832ab6e87b7c89bfb87b